### PR TITLE
Remove a deprecation warning after upgrading to rails 2.3.10

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 unless $gems_rake_task
-  if Rails.version <= "2.3.7"
+  if (Rails.version.split('.').map(&:to_i) <=> "2.3.7".split('.').map(&:to_i)) < 1
     $stderr.puts "rails_xss requires Rails 2.3.8 or later. Please upgrade to enable automatic HTML safety."
   else
     require 'rails_xss'


### PR DESCRIPTION
Upgrading to Rails 2.3.9 introduces a new deprecation warning by mistake.
