### PR TITLE
Ruby string version compare bug 

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,8 @@
 unless $gems_rake_task
-  if Rails.version <= "2.3.7"
-    $stderr.puts "rails_xss requires Rails 2.3.8 or later. Please upgrade to enable automatic HTML safety."
-  else
+  major, minor, micro = Rails.version.split(".").map(&:to_i)
+  if major == 2 && minor == 3 && micro >= 8
     require 'rails_xss'
+  else
+    $stderr.puts "rails_xss requires Rails 2.3.8 or later. Please upgrade to enable automatic HTML safety."
   end
 end


### PR DESCRIPTION
To Whom it may concern,

The issue (present in both Ruby 1.8 and 1.9) is demonstrated here: http://gist.github.com/627680

I'm really not in love with this patch, but the issue needs to be addressed and I had an immediate need so I thought I'd forward this along. I'd like to learn a more 'right' way to address this if there is one.

Thanks for making great software available for everyone.
- Phil
