### PR TITLE
rails_xss does not load with Rails 2.3.10

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 unless $gems_rake_task
-  if Rails.version <= "2.3.7"
+  if Rails::VERSION::MAJOR != 2 || Rails::VERSION::MINOR != 3 || Rails::VERSION::TINY < 8
     $stderr.puts "rails_xss requires Rails 2.3.8 or later. Please upgrade to enable automatic HTML safety."
   else
     require 'rails_xss'


### PR DESCRIPTION
In init.rb, a version comparison is made to determine whether or not to require rails_xss. This fails with Rails 2.3.10 because:

"2.3.10" <= "2.3.7" => true
