### PR TITLE
rails_xss does not work with Rails 2.3.10 due to a version comparison bug

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 unless $gems_rake_task
-  if Rails.version <= "2.3.7"
+  if Rails::VERSION::MAJOR != 2 || Rails::VERSION::MINOR != 3 || Rails::VERSION::TINY < 8
     $stderr.puts "rails_xss requires Rails 2.3.8 or later. Please upgrade to enable automatic HTML safety."
   else
     require 'rails_xss'


### PR DESCRIPTION
Now uses Rails::VERSION::X to compare version.
