### PR TITLE
duplicate test class name and a duplicate test method name

### DIFF
--- a/test/content_for_test.rb
+++ b/test/content_for_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UrlHelperTest < ActionView::TestCase
+class ContentForTest < ActionView::TestCase
 
   def test_content_for_should_yield_html_safe_string
     content_for(:testing, "Some <p>html</p>")

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -269,7 +269,7 @@ class FormHelperTest < ActionView::TestCase
       hidden_field("post", "title")
   end
 
-  def test_text_field_with_options
+  def test_hidden_field_with_options
     assert_dom_equal '<input id="post_title" name="post[title]" type="hidden" value="Something Else" />',
       hidden_field("post", "title", :value => "Something Else")
   end


### PR DESCRIPTION
Small cleanups to fix a duplicate test class name and a duplicate test method name.
