### PR TITLE
Fix escape_javascript to support SafeBuffer strings

### DIFF
--- a/lib/rails_xss/action_view.rb
+++ b/lib/rails_xss/action_view.rb
@@ -79,6 +79,16 @@ module ActionView
         end
       end
     end
+    
+    module JavaScriptHelper
+      def escape_javascript(javascript)
+        if javascript
+          javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) {|match| JS_ESCAPE_MAP[match] }
+        else
+          ''
+        end
+      end
+    end
   end
 end
 

--- a/test/javascript_helper_test.rb
+++ b/test/javascript_helper_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class JavascriptHelperTest < ActionView::TestCase
+  def test_escape_javascript_with_safebuffer
+    given = %('quoted' "double-quoted" new-line:\n </closed>)
+    expect = %(\\'quoted\\' \\"double-quoted\\" new-line:\\n <\\/closed>)
+    assert_equal expect, escape_javascript(given)
+    assert_equal expect, escape_javascript(ActiveSupport::SafeBuffer.new(given))
+  end
+end


### PR DESCRIPTION
I ran into escape_javascript problems on Rails 2.3.14 using rails_xss. It appears to be related to this Rails issue:

https://github.com/rails/rails/issues/1553

I basically added the escape_javascript method and the test from the pull request that fixed Rails 1553:

https://github.com/rails/rails/pull/1558
