### PR TITLE
fixed eval block line offset

### DIFF
--- a/lib/rails_xss/string_ext.rb
+++ b/lib/rails_xss/string_ext.rb
@@ -12,7 +12,7 @@ ActiveSupport::SafeBuffer.class_eval do
   UNSAFE_STRING_METHODS = ["capitalize", "chomp", "chop", "delete", "downcase", "gsub", "lstrip", "next", "reverse", "rstrip", "slice", "squeeze", "strip", "sub", "succ", "swapcase", "tr", "tr_s", "upcase"].freeze
 
   for unsafe_method in UNSAFE_STRING_METHODS
-    class_eval <<-EOT, __FILE__, __LINE__
+    class_eval <<-EOT, __FILE__, __LINE__ + 1
       def #{unsafe_method}(*args)
         super.to_str
       end


### PR DESCRIPTION
For errors raised inside of the eval block in string_ext.rb, the line number is off by 1 because the offset points to the wrong line number. So, add one.
