### PR TITLE
stop erubis from printing its version number all the time

### DIFF
--- a/lib/rails_xss/erubis.rb
+++ b/lib/rails_xss/erubis.rb
@@ -1,4 +1,10 @@
-require 'erubis/helpers/rails_helper'
+# stop erubis from printing it's version number all the time
+old_stdout = $stdout
+File.open("/dev/null", "w") do |f|
+  $stdout = f
+  require 'erubis/helpers/rails_helper'
+  $stdout = old_stdout
+end
 
 module RailsXss
   class Erubis < ::Erubis::Eruby


### PR DESCRIPTION
```
** Erubis 2.6.6
```

It's so annoying :D
