### PR TITLE
Patch to allow simple_format to behave as in Rails 3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,15 @@ Gotchas
 Both these methods support arbitrary HTML and are *not* safe to embed directly in your document.  You'll need to do something like:
 
     <%= sanitize(textilize(@blog_post.content_textile)) %>
+    
+simple_format has been patched to behave like the Rails 3 method, which supports an options hash with a 'sanitize' flag, eg:
+
+simple_format(text, html_options={}, options={})
+
+The sanitize flag defaults to true, but if passed as false, the text will not be sanitized, eg:
+
+simple_format("<script>potentially evil js</script>", {}, { :sanitize => false })
+=> "<p><script>potentially evil js</script></p>"
 
 #### Safe strings aren't magic.
 

--- a/README.markdown
+++ b/README.markdown
@@ -65,12 +65,12 @@ Both these methods support arbitrary HTML and are *not* safe to embed directly i
     
 simple_format has been patched to behave like the Rails 3 method, which supports an options hash with a 'sanitize' flag, eg:
 
-simple_format(text, html_options={}, options={})
+	simple_format(text, html_options={}, options={})
 
 The sanitize flag defaults to true, but if passed as false, the text will not be sanitized, eg:
 
-simple_format("<script>potentially evil js</script>", {}, { :sanitize => false })
-=> "<p><script>potentially evil js</script></p>"
+	simple_format("<script>potentially evil js</script>", {}, { :sanitize => false })
+	=> "<p><script>potentially evil js</script></p>"
 
 #### Safe strings aren't magic.
 

--- a/lib/rails_xss/action_view.rb
+++ b/lib/rails_xss/action_view.rb
@@ -33,9 +33,9 @@ module ActionView
         output_buffer.concat(string)
       end
 
-      def simple_format(text, html_options={})
+      def simple_format(text, html_options={}, options={:sanitize => true})
         start_tag = tag('p', html_options, true)
-        text = ERB::Util.h(text).to_str.dup
+        text = options[:sanitize] ? ERB::Util.h(text).to_str.dup : text.to_str.dup
         text.gsub!(/\r\n?/, "\n")                    # \r\n and \r -> \n
         text.gsub!(/\n\n+/, "</p>\n\n#{start_tag}")  # 2+ newline  -> paragraph
         text.gsub!(/([^\n]\n)(?=[^\n])/, '\1<br />') # 1 newline   -> br

--- a/test/text_helper_test.rb
+++ b/test/text_helper_test.rb
@@ -24,6 +24,11 @@ class TextHelperTest < ActionView::TestCase
                      simple_format('This is <script>evil_js</script>.'))
   end
 
+  def test_simple_format_should_not_escape_unsafe_content_when_sanitize_option_unset
+    assert_dom_equal(%(<p>This is <script>potentially_evil_js</script>.</p>),
+                     simple_format('This is <script>potentially_evil_js</script>.', {}, { :sanitize => false })
+  end
+
   def test_truncate_should_not_be_html_safe
     assert !truncate("Hello World!", :length => 12).html_safe?
   end


### PR DESCRIPTION
This patch allows simple_format to accept an options hash with the 'sanitize' parameter, consistent with Rails 3.

By default, the sanitize parameter will be true, and escaping will occur.  However, if you pass :sanitize => false, the string will not be sanitized during formatting.

Test case included.
