### PR TITLE
Warn users that safe_helper is not supported in Rails 3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,13 +28,14 @@ With this plugin installed, the html will be escaped.  So you will need to do on
       end.join("\n").html_safe
     end
   
-3) Use the safe_helper meta programming method:
+3) Use the `safe_helper` meta programming method (WARNING: This is not supported by Rails 3, so if you're planning to
+eventually upgrade your app this alternative is not recommended):
 
     module ApplicationHelper
       def some_helper
         #...
       end
-      safe_helper :some_helper
+      safe_helper :some_helper    # not supported by Rails 3
     end  
 
 Example


### PR DESCRIPTION
This simple warning can avoid a ton of work by those who are upgrading from Rails 2, like this poor soul:

http://www.dixis.com/?p=463
